### PR TITLE
Eliminación de SICOM y de la mala utilización de la palabra comunicación

### DIFF
--- a/ley_Diputados.md
+++ b/ley_Diputados.md
@@ -6,17 +6,17 @@ EL CONGRESO DE LA NACIÓN PARAGUAYA SANCIONA CON FUERZA DE
 
 # L E Y: MITIC
 
-###Art. 1º.- Objeto.  
+### Art. 1º.- Objeto.  
 La presente ley tiene por objeto crear el Ministerio de Tecnologías de la Información y Comunicación, en adelante el «Ministerio», identificado con las siglas «MITIC», en sustitución de la Secretaría Nacional de Tecnologías de la Información y Comunicación «SENATICS» y de la Secretaría de Información y Comunicación para el Desarrollo «SICOM», y establecer su carta orgánica y funciones, así como los órganos que lo conforman.
 
-###Art. 2º.- 
+### Art. 2º.- 
 El «Ministerio» es un órgano del Poder Ejecutivo, de derecho público. Se constituye en la entidad técnica e instancia rectora, normativa, estratégica y de gestión especializada, para formulación de políticas e implementación de planes y proyectos en el ámbito de las Tecnologías de la Información y Comunicación en el sector público, y de la comunicación del Poder Ejecutivo tanto en su aspecto social como educativo para la inclusión, apropiación e innovación en la creación, uso e implementación de las tecnologías.
 
-###Art. 3º.- 
+### Art. 3º.- 
 El «Ministerio» constituye su domicilio legal en la ciudad de Asunción, pudiendo establecer oficinas regionales, departamentales y distritales. 
 Toda acción judicial en la que el «Ministerio» sea parte deberá iniciarse única y exclusivamente ante los Juzgados y Tribunales de la circunscripción judicial de la Capital de la República, salvo que el «Ministerio» acepte expresamente someterse a otra jurisdicción, en ese caso se podrá constituir otros domicilios procesales.
 
-###Art. 4º.- 
+### Art. 4º.- 
 Principios Generales.
 Toda actuación relacionada con la presente ley debe observar los siguientes principios generales:                         
 **1.	Planificación.** Las políticas públicas que se apliquen deben originarse en un adecuado diagnóstico de la situación y servir de base para la planificación de las estrategias, objetivos, metas y acciones que serán emprendidas por el «Ministerio» en sus diferentes ámbitos de actuación.                                                                                                                     
@@ -26,7 +26,7 @@ Toda actuación relacionada con la presente ley debe observar los siguientes pri
 **5.	Libre Adopción Tecnológica.** El Estado garantizará la libre adopción de tecnologías por parte de los habitantes del territorio nacional, y los Organismos y Entidades del Estado lo adoptarán a través de los lineamientos del Plan Director de Tecnologías de la Información y Comunicación, que permitan fomentar la eficiente prestación de servicios, contenidos y aplicaciones que utilicen Tecnologías de la Información y Comunicación, para garantizar la libertad de uso por parte de los habitantes del territorio nacional, de manera que su adopción sea a su vez armónica con el desarrollo  sostenible.                                           
 **6.	Masificación del Gobierno Electrónico.** Con el fin de lograr la prestación de servicios eficientes a todos los sectores de la sociedad, las entidades públicas deberán adoptar todas las medidas necesarias para garantizar el máximo aprovechamiento de las Tecnologías de la Información y Comunicación en el desarrollo de sus funciones. El Gobierno Nacional fijará los mecanismos y condiciones para garantizar el desarrollo de este principio. Y en la reglamentación correspondiente, establecerá los plazos, términos y prescripciones, no solamente para la instalación de las infraestructuras indicadas y necesarias, sino también para mantener actualizadas y con la información completa, los medios e instrumentos tecnológicos.
 
-###Art. 5º.- Glosario
+### Art. 5º.- Glosario
 A los efectos de la presente ley, se entenderá por:
 **1.	«MITIC»:** Ministerio de Tecnologías de la Información y Comunicación.
 **2.	«OEE»:** Organismos y Entidades del Estado.
@@ -39,14 +39,14 @@ A los efectos de la presente ley, se entenderá por:
 **9.	«AEP»:** Agencia Espacial del Paraguay.
 **10. «IID»:** Investigación, Innovación y Desarrollo
 
-###Art. 6º.- Objetivos del Ministerio.
+### Art. 6º.- Objetivos del Ministerio.
 El «Ministerio» tendrá los siguientes objetivos:
 **1.**	Elaborar, promover, implementar y supervisar las políticas públicas, planes, programas y proyectos del sector de las Tecnologías de la Información y la Comunicación y de sectores convergentes, así como su ordenamiento general, en concordancia con la Constitución de la República del Paraguay y las leyes.
 **2.**	Promover, incrementar y facilitar el uso de las «TIC», buscando siempre la participación y el acceso efectivo en igualdad de oportunidades a todos los habitantes de la República, con la mayor cobertura y calidad de servicios posibles; así como propiciar el uso eficiente de las redes informáticas, la IID, formación del talento humano y la competencia a nivel nacional e internacional. 
 **3.**	Impulsar el desarrollo y el fortalecimiento del sector, la innovación tecnológica, economía digital, mediante políticas públicas que involucren a todos los niveles de los «OEE» y de la sociedad.
 **4.**	Desarrollar procesos y estrategias de Comunicación para la difusión de la información que generen los «OEE» y la parte paraguaya de los Organismos Binacionales o Multilaterales, de manera a lograr que la difusión de la información sea realizada en forma ágil y oportuna e incentivando la apropiación social y educativa de las tecnologías para implementación adecuada, una interacción comunicacional participativa, plural y transparente entre el Poder Ejecutivo y los habitantes de la República del Paraguay.
 
-###Art. 7º.- Competencias.
+### Art. 7º.- Competencias.
 El «Ministerio», tendrá las siguientes competencias: 
 **1.**	Diseñar, planificar, adoptar, ejecutar y promover las políticas, planes, programas y proyectos del sector de las Tecnologías de la Información y Comunicación que contribuyan al mejoramiento de la calidad de vida de las comunidades, el acceso a las nuevas tecnologías y a la información de manera a contribuir a generar oportunidades de educación, trabajo, salud, justicia, cultura y recreación, entre otras.
 **2.**	Establecer y gestionar políticas de protección de la información personal y gubernamental, y cultivar los conocimientos sobre la industria de seguridad de la información, para lo cual deberá establecer un sistema de organización de seguridad, proponer una política de seguridad a nivel nacional, y establecer un plan de integración de protección de información.
@@ -74,10 +74,10 @@ El «Ministerio», tendrá las siguientes competencias:
 **24.**	Definir y designar los sistemas, procesos y tecnologías de información que serán considerados Infraestructura TICs crítica para el funcionamiento del Estado Paraguayo
 **25.**	Salvaguardar la efectiva capacidad de gestión de la infraestructura TICs crítica para el funcionamiento del Estado Paraguayo.
 
-###Art. 8º.- El Ministro. 
+### Art. 8º.- El Ministro. 
 El Ministro es la máxima autoridad institucional. En tal carácter es el responsable de la dirección y de la gestión especializada, técnica, financiera y administrativa de la Entidad, en el ámbito de sus atribuciones legales, asimismo, ejerce la representación legal del «Ministerio».
 
-###Art. 9º.- Nombramiento, requisitos, incompatibilidades e inmunidades.
+### Art. 9º.- Nombramiento, requisitos, incompatibilidades e inmunidades.
 El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los siguientes requisitos:
 **1.**	Ser paraguayo natural; 
 **2.**	Haber cumplido veinticinco (25) años de edad; 
@@ -85,7 +85,7 @@ El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los s
 **4.**	Estar en pleno goce de los derechos civiles y políticos. No registrar antecedentes de mal desempeño en la función pública.
 **5.**	La función de Ministro es incompatible con el ejercicio de otra actividad o cargo público o privado, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones, salvo el ejercicio de la docencia.
 
-###Art. 10º.- Deberes y atribuciones.
+### Art. 10º.- Deberes y atribuciones.
 Son deberes y atribuciones del Ministro:
 1.	Ejercer la dirección, administración, supervisión y control del «Ministerio», tomando las decisiones que estime necesarias para la buena gestión del mismo.
 2.	Elaborar y ejecutar los programas, proyectos, planes y políticas generales del «Ministerio».
@@ -118,7 +118,7 @@ Son deberes y atribuciones del Ministro:
 29.	Las demás funciones que fuesen establecidas por leyes especiales o aquellas necesarias para el correcto funcionamiento del «Ministerio»; y,
 30.	Cumplir y hacer cumplir la presente ley, su reglamentación y las demás disposiciones conexas.
 
-###Art. 11º.- Estructura Orgánica. -
+### Art. 11º.- Estructura Orgánica. -
 El «Ministerio» contará con la siguiente estructura orgánica:
 a)	Ministro;
 b)	Dirección General de Gabinete Ministerial;
@@ -131,7 +131,7 @@ h)	Auditoría Interna; y,
 i)	Otras Direcciones Generales y dependencias que fueren necesarias para el cumplimiento de los objetivos del «Ministerio».
 En caso de sustitución del Ministro, los cargos de los titulares de las unidades orgánicas detalladas en el presente artículo, estarán a disposición de la nueva autoridad designada por el Poder Ejecutivo, pudiendo ser reasignados según necesidad o destituidos sin más trámites por término de funciones.
 
-###Art. 12º.- Direcciones Generales y otras dependencias.
+### Art. 12º.- Direcciones Generales y otras dependencias.
 El «Ministerio» podrá incorporar en su organigrama a las Direcciones Generales o dependencias similares que considere necesarias para el cumplimiento de sus objetivos. Los Viceministerios contarán cuanto menos con las siguientes Direcciones Generales:
 1.	Viceministerio de Tecnologías de la Información y Comunicación (TIC):
 a)	Dirección General de Infraestructura y Conectividad
@@ -145,23 +145,23 @@ b)	Dirección General de Comunicación Estratégica.
 c)	Dirección General de Información Presidencial.
 d)	Dirección General de Medios del Estado.
 
-###Art. 13º.- Nombramientos.
+### Art. 13º.- Nombramientos.
 Los Viceministros, el Director General de Gabinete, el Secretario General, el Asesor Jurídico, el Auditor Interno y el Director General de Administración y Finanzas serán nombrados por decreto del Poder Ejecutivo, a propuesta del Ministro. Las personas nombradas en dichos cargos estarán sujetas a la libre disposición del Presidente de la República, conforme con la Ley de la Función Pública. 
 Los demás cargos serán nombrados por resolución del Ministro, de conformidad a lo establecido en la Ley de la Función Pública y sus reglamentaciones.
 
-###Art. 14º.- Requisitos e incompatibilidades.
+### Art. 14º.- Requisitos e incompatibilidades.
 Para ejercer los cargos de Viceministros, Secretario General, Directores Generales y Directores del «Ministerio» se requerirá, tener nacionalidad paraguaya, haber cumplido veinticinco (25) años de edad, tener probada idoneidad en la materia y cumplir con los demás requisitos establecidos en la Ley de la Función Pública que no contraríen los que se establecen en este artículo.
 Dichos cargos serán ejercidos a tiempo completo y con dedicación exclusiva y es incompatible con el ejercicio de otra actividad, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones salvo el ejercicio de la docencia a tiempo parcial y opuesto al horario laboral siempre que ella no perturbe el ejercicio de sus funciones.
 
-###Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
+### Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
 Se podrá modificar y ampliar la estructura organizacional y los niveles de dependencias del «Ministerio», y establecer las funciones y atribuciones de las mismas conforme a las competencias asignadas en la presente ley, por decreto del Poder Ejecutivo.
 
-###Art. 16º.- Patrimonio.
+### Art. 16º.- Patrimonio.
 El patrimonio del «Ministerio» está constituido por:
 1.	La totalidad del activo y pasivo de la «SENATICS» y de la «SICOM» constituidos por muebles, inmuebles, derechos, acciones, garantías o privilegios, subrogándose de pleno derecho al «Ministerio» en todas las acciones y derechos que aquellas Instituciones detentan a la fecha.
 2.	Los bienes adquiridos en el futuro para el cumplimiento de sus fines.
 
-###Art. 17º.- Recursos Económicos.
+### Art. 17º.- Recursos Económicos.
 Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
 1.	Las asignaciones y subvenciones fijadas en el Presupuesto General de la Nación (PGN) para el «Ministerio» en cada ejercicio fiscal;
 2.	Los bienes que le trasfieran el Estado paraguayo o los que adquiera legalmente a cualquier título y los frutos de tales bienes;
@@ -175,7 +175,7 @@ Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
 10.	Otros recursos que se le asignen.
 11.	Los recursos provenientes de los fondos del «FONTIC» destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de sus fines.
 
-###Art. 18º.- Absorción del «FONTIC». Componentes.  
+### Art. 18º.- Absorción del «FONTIC». Componentes.  
 El «Ministerio» absorbe como parte de sus recursos económicos, el «FONTED» el cual pasará a llamarse «FONTIC», constituido con la finalidad de lograr los objetivos vinculados con programas de Tecnología de la Información y Comunicación
 Forman parte del «FONTIC»:
 1.	Los fondos provenientes de convenios o acuerdos con instituciones nacionales o internacionales, públicas o privadas que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC».
@@ -184,54 +184,54 @@ Forman parte del «FONTIC»:
 4.	Los recursos provenientes de los Royalties y Compensaciones que corresponden a la Administración Central, de conformidad a lo establecido en el inciso a) del Artículo 1º de la Ley Nº 3984/2010, en un monto que deberá establecerse en cada Ejercicio Fiscal.
 5.	Además, podrán formar parte de los recursos del «FONTIC» las donaciones, legados, transferencias u otros aportes, por cualquier título proveniente de personas naturales o jurídicas nacionales o extranjeras, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
 
-###Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
+### Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
 Las autoridades y el personal afectado al servicio de los «OEE» y los del sector privado estarán obligados a colaborar en la expedición y facilitación de los datos e informaciones requeridas por el «Ministerio». A tal fin facilitarán al mismo cuantos informes y documentos se le soliciten en relación al ejercicio de las atribuciones del «Ministerio»; prestarán la ayuda y la cooperación que precise el mismo para el adecuado, eficiente y eficaz ejercicio de su competencia.
 
-###Art. 20º.- Adecuación Presupuestaria.	
+### Art. 20º.- Adecuación Presupuestaria.	
 El Poder Ejecutivo podrá reprogramar y adecuar las correspondientes partidas presupuestarias, en el marco del Presupuesto General de la Nación, adecuándolas a la nueva estructura dispuesta en la presente Ley. 
 
-###Art. 21º.- Coordinación. -	
+### Art. 21º.- Coordinación. -	
 A los efectos de la presente ley, el «Ministerio» coordinará con el Ministerio de Hacienda el ajuste de conciliación de las cuentas, cargos y presupuestos.
 
-###Art. 22º.- Reglamentación.
+### Art. 22º.- Reglamentación.
 La utilización de los medios electrónicos deberá ser reglamentada y deberá aplicarse conforme lo establece la legislación vigente en la materia.
 
-###Art. 23º.- Personal, bienes y recursos financieros.
+### Art. 23º.- Personal, bienes y recursos financieros.
 A partir de la vigencia de la presente ley, el personal, bienes y recursos financieros de la «SENATICS» y de la «SICOM» pasarán a formar parte del «Ministerio».  
 Todos los derechos y acciones atribuidos por leyes especiales a la «SENATICS» y a la «SICOM», quedan subrogados a favor del «Ministerio».
 A los efectos de determinar el patrimonio del «Ministerio», la «SENATICS» y la «SICOM» deberán proceder a un inventario general de los bienes, derechos y obligaciones.
 
-###Art. 24º.- Personal.
+### Art. 24º.- Personal.
 1.	El personal que, a la fecha de la promulgación de la presente ley, forme parte del anexo del personal de la «SENATICS» y de la «SICOM», pasará a formar parte de la nómina inicial del «Ministerio» y gozará de la misma antigüedad, régimen de jubilación y demás derechos adquiridos. Se regirán por esta ley, sus reglamentos, la Ley de la Función Pública, sus normas complementarias y reglamentarias.
 2.	El personal, que a la fecha de promulgación de esta ley forme parte del anexo del personal de la «SENATICS» y de la «SICOM», y que ya cumpliese con los requisitos de la jubilación ordinaria, deberá acogerse a los beneficios de la misma.
 3.	El personal contratado que se encuentre prestando servicios en la «SENATICS» y en la «SICOM», continuará prestando dichos servicios en los mismos términos y condiciones contractuales.
 4.	El Ministro del «Ministerio» podrá implementar un sistema de retiro voluntario incentivado, de acuerdo con la disponibilidad presupuestaria, para el personal que, a la fecha de la promulgación de la presente ley, desee acogerse a los beneficios de este sistema.
 
-###Art. 25º.- Facultades Especiales. Restructuración cuadro de asignación y reformulación del presupuesto.
+### Art. 25º.- Facultades Especiales. Restructuración cuadro de asignación y reformulación del presupuesto.
 1.	El Ministro del «Ministerio», queda autorizado a reestructurar el cuadro de asignación de personal y a reformular el proyecto de presupuesto correspondiente al Ejercicio Fiscal vigente, en el marco de las disposiciones legales vigentes y en concordancia con la organización establecida en la presente ley.
 2.	El Ministro del «Ministerio» será responsable de definir y aprobar el organigrama institucional, los manuales de cargos y funciones, los manuales de procedimientos y las atribuciones y procedimientos del área de coordinación mencionados en la presente ley, correspondiente al «Ministerio», en un plazo no mayor de ciento ochenta días (180) días, contados a partir de su designación.
 
-###Art. 26º.- Relaciones con «CONATEL» «COPACO» y «AEP»
+### Art. 26º.- Relaciones con «CONATEL» «COPACO» y «AEP»
 A partir de la entrada en vigencia de la presente ley, las relaciones de la Comisión Nacional de Telecomunicaciones «CONATEL» con el Poder Ejecutivo, se canalizarán a través del «Ministerio» en sustitución del Ministerio de Obras Públicas y Comunicaciones, según lo establecido en el artículo 6 de la Ley N° 642/95 “De Telecomunicaciones”.
 A partir de la entrada en vigencia de la presente Ley las relaciones de la «COPACO» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
 A partir de la entrada en vigencia de la presente Ley las relaciones de la «AEP» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
 
-###Art. 27º.- De la Integración del Consejo Nacional de Ciencia y Tecnología (CONACYT)
+### Art. 27º.- De la Integración del Consejo Nacional de Ciencia y Tecnología (CONACYT)
 El «Ministerio» integrará el Consejo Nacional de Ciencia y Tecnología (CONACYT), para lo cual el Ministro deberá designar a un representante titular y un representante suplente, los cuales serán nombrados como consejeros por Decreto del Poder Ejecutivo. 
 
-###Art. 28º.- Extinción de «SENATICS» y «SICOM».
+### Art. 28º.- Extinción de «SENATICS» y «SICOM».
 La «SENATICS» y la «SICOM» dependiente de la Presidencia de la República, quedarán extinguidas de pleno derecho a partir de la entrada en vigencia de la presente ley.
 
-###Art. 29 º.- Derogación.
+### Art. 29 º.- Derogación.
 Queda derogada la Ley Nº 4989/ 2013 «Que crea el Marco de Aplicación de las Tecnologías de la Información y Comunicación en el Sector Público y crea la Secretaría Nacional de la Tecnologías de la Información y Comunicación (SENATICS)» y todas las disposiciones contrarias a la presente Ley a partir de su entrada en vigor.
 
-###Art. 30º.- Tiempo máximo de adecuación.
+### Art. 30º.- Tiempo máximo de adecuación.
 El «Ministerio» y los demás «OEE» afectados por esta ley, deberán adecuar sus dependencias y funciones a lo establecido en la presente ley, en un plazo no mayor a doce (12) meses, contados a partir de su promulgación y publicación.
 
-###Art. 31º.- Reglamentación.
+### Art. 31º.- Reglamentación.
 El Poder Ejecutivo reglamentará la presente ley en un plazo no mayor a ciento veinte (120) días, contados a partir de su promulgación y publicación.
 
-###Art. 32º.- Vigencia.
+### Art. 32º.- Vigencia.
 La presente Ley entrará en vigencia a partir del día siguiente de la publicación en la Gaceta Oficial de la República del Paraguay.
 
-###Art. 33º.- Comuníquese al Poder Ejecutivo.
+### Art. 33º.- Comuníquese al Poder Ejecutivo.

--- a/ley_Diputados.md
+++ b/ley_Diputados.md
@@ -6,17 +6,17 @@ EL CONGRESO DE LA NACIÓN PARAGUAYA SANCIONA CON FUERZA DE
 
 # L E Y: MITIC
 
-##Art. 1º.- Objeto.  
+###Art. 1º.- Objeto.  
 La presente ley tiene por objeto crear el Ministerio de Tecnologías de la Información y Comunicación, en adelante el «Ministerio», identificado con las siglas «MITIC», en sustitución de la Secretaría Nacional de Tecnologías de la Información y Comunicación «SENATICS» y de la Secretaría de Información y Comunicación para el Desarrollo «SICOM», y establecer su carta orgánica y funciones, así como los órganos que lo conforman.
 
-##Art. 2º.- 
+###Art. 2º.- 
 El «Ministerio» es un órgano del Poder Ejecutivo, de derecho público. Se constituye en la entidad técnica e instancia rectora, normativa, estratégica y de gestión especializada, para formulación de políticas e implementación de planes y proyectos en el ámbito de las Tecnologías de la Información y Comunicación en el sector público, y de la comunicación del Poder Ejecutivo tanto en su aspecto social como educativo para la inclusión, apropiación e innovación en la creación, uso e implementación de las tecnologías.
 
-##Art. 3º.- 
+###Art. 3º.- 
 El «Ministerio» constituye su domicilio legal en la ciudad de Asunción, pudiendo establecer oficinas regionales, departamentales y distritales. 
 Toda acción judicial en la que el «Ministerio» sea parte deberá iniciarse única y exclusivamente ante los Juzgados y Tribunales de la circunscripción judicial de la Capital de la República, salvo que el «Ministerio» acepte expresamente someterse a otra jurisdicción, en ese caso se podrá constituir otros domicilios procesales.
 
-##Art. 4º.- 
+###Art. 4º.- 
 Principios Generales.
 Toda actuación relacionada con la presente ley debe observar los siguientes principios generales:                         
 **1.	Planificación.** Las políticas públicas que se apliquen deben originarse en un adecuado diagnóstico de la situación y servir de base para la planificación de las estrategias, objetivos, metas y acciones que serán emprendidas por el «Ministerio» en sus diferentes ámbitos de actuación.                                                                                                                     
@@ -26,7 +26,7 @@ Toda actuación relacionada con la presente ley debe observar los siguientes pri
 **5.	Libre Adopción Tecnológica.** El Estado garantizará la libre adopción de tecnologías por parte de los habitantes del territorio nacional, y los Organismos y Entidades del Estado lo adoptarán a través de los lineamientos del Plan Director de Tecnologías de la Información y Comunicación, que permitan fomentar la eficiente prestación de servicios, contenidos y aplicaciones que utilicen Tecnologías de la Información y Comunicación, para garantizar la libertad de uso por parte de los habitantes del territorio nacional, de manera que su adopción sea a su vez armónica con el desarrollo  sostenible.                                           
 **6.	Masificación del Gobierno Electrónico.** Con el fin de lograr la prestación de servicios eficientes a todos los sectores de la sociedad, las entidades públicas deberán adoptar todas las medidas necesarias para garantizar el máximo aprovechamiento de las Tecnologías de la Información y Comunicación en el desarrollo de sus funciones. El Gobierno Nacional fijará los mecanismos y condiciones para garantizar el desarrollo de este principio. Y en la reglamentación correspondiente, establecerá los plazos, términos y prescripciones, no solamente para la instalación de las infraestructuras indicadas y necesarias, sino también para mantener actualizadas y con la información completa, los medios e instrumentos tecnológicos.
 
-##Art. 5º.- Glosario
+###Art. 5º.- Glosario
 A los efectos de la presente ley, se entenderá por:
 **1.	«MITIC»:** Ministerio de Tecnologías de la Información y Comunicación.
 **2.	«OEE»:** Organismos y Entidades del Estado.
@@ -39,14 +39,14 @@ A los efectos de la presente ley, se entenderá por:
 **9.	«AEP»:** Agencia Espacial del Paraguay.
 **10. «IID»:** Investigación, Innovación y Desarrollo
 
-##Art. 6º.- Objetivos del Ministerio.
+###Art. 6º.- Objetivos del Ministerio.
 El «Ministerio» tendrá los siguientes objetivos:
 **1.**	Elaborar, promover, implementar y supervisar las políticas públicas, planes, programas y proyectos del sector de las Tecnologías de la Información y la Comunicación y de sectores convergentes, así como su ordenamiento general, en concordancia con la Constitución de la República del Paraguay y las leyes.
 **2.**	Promover, incrementar y facilitar el uso de las «TIC», buscando siempre la participación y el acceso efectivo en igualdad de oportunidades a todos los habitantes de la República, con la mayor cobertura y calidad de servicios posibles; así como propiciar el uso eficiente de las redes informáticas, la IID, formación del talento humano y la competencia a nivel nacional e internacional. 
 **3.**	Impulsar el desarrollo y el fortalecimiento del sector, la innovación tecnológica, economía digital, mediante políticas públicas que involucren a todos los niveles de los «OEE» y de la sociedad.
 **4.**	Desarrollar procesos y estrategias de Comunicación para la difusión de la información que generen los «OEE» y la parte paraguaya de los Organismos Binacionales o Multilaterales, de manera a lograr que la difusión de la información sea realizada en forma ágil y oportuna e incentivando la apropiación social y educativa de las tecnologías para implementación adecuada, una interacción comunicacional participativa, plural y transparente entre el Poder Ejecutivo y los habitantes de la República del Paraguay.
 
-##Art. 7º.- Competencias.
+###Art. 7º.- Competencias.
 El «Ministerio», tendrá las siguientes competencias: 
 **1.**	Diseñar, planificar, adoptar, ejecutar y promover las políticas, planes, programas y proyectos del sector de las Tecnologías de la Información y Comunicación que contribuyan al mejoramiento de la calidad de vida de las comunidades, el acceso a las nuevas tecnologías y a la información de manera a contribuir a generar oportunidades de educación, trabajo, salud, justicia, cultura y recreación, entre otras.
 **2.**	Establecer y gestionar políticas de protección de la información personal y gubernamental, y cultivar los conocimientos sobre la industria de seguridad de la información, para lo cual deberá establecer un sistema de organización de seguridad, proponer una política de seguridad a nivel nacional, y establecer un plan de integración de protección de información.
@@ -74,10 +74,10 @@ El «Ministerio», tendrá las siguientes competencias:
 **24.**	Definir y designar los sistemas, procesos y tecnologías de información que serán considerados Infraestructura TICs crítica para el funcionamiento del Estado Paraguayo
 **25.**	Salvaguardar la efectiva capacidad de gestión de la infraestructura TICs crítica para el funcionamiento del Estado Paraguayo.
 
-##Art. 8º.- El Ministro. 
+###Art. 8º.- El Ministro. 
 El Ministro es la máxima autoridad institucional. En tal carácter es el responsable de la dirección y de la gestión especializada, técnica, financiera y administrativa de la Entidad, en el ámbito de sus atribuciones legales, asimismo, ejerce la representación legal del «Ministerio».
 
-##Art. 9º.- Nombramiento, requisitos, incompatibilidades e inmunidades.
+###Art. 9º.- Nombramiento, requisitos, incompatibilidades e inmunidades.
 El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los siguientes requisitos:
 **1.**	Ser paraguayo natural; 
 **2.**	Haber cumplido veinticinco (25) años de edad; 
@@ -85,7 +85,7 @@ El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los s
 **4.**	Estar en pleno goce de los derechos civiles y políticos. No registrar antecedentes de mal desempeño en la función pública.
 **5.**	La función de Ministro es incompatible con el ejercicio de otra actividad o cargo público o privado, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones, salvo el ejercicio de la docencia.
 
-##Art. 10º.- Deberes y atribuciones.
+###Art. 10º.- Deberes y atribuciones.
 Son deberes y atribuciones del Ministro:
 1.	Ejercer la dirección, administración, supervisión y control del «Ministerio», tomando las decisiones que estime necesarias para la buena gestión del mismo.
 2.	Elaborar y ejecutar los programas, proyectos, planes y políticas generales del «Ministerio».
@@ -118,7 +118,7 @@ Son deberes y atribuciones del Ministro:
 29.	Las demás funciones que fuesen establecidas por leyes especiales o aquellas necesarias para el correcto funcionamiento del «Ministerio»; y,
 30.	Cumplir y hacer cumplir la presente ley, su reglamentación y las demás disposiciones conexas.
 
-##Art. 11º.- Estructura Orgánica. -
+###Art. 11º.- Estructura Orgánica. -
 El «Ministerio» contará con la siguiente estructura orgánica:
 a)	Ministro;
 b)	Dirección General de Gabinete Ministerial;
@@ -131,7 +131,7 @@ h)	Auditoría Interna; y,
 i)	Otras Direcciones Generales y dependencias que fueren necesarias para el cumplimiento de los objetivos del «Ministerio».
 En caso de sustitución del Ministro, los cargos de los titulares de las unidades orgánicas detalladas en el presente artículo, estarán a disposición de la nueva autoridad designada por el Poder Ejecutivo, pudiendo ser reasignados según necesidad o destituidos sin más trámites por término de funciones.
 
-##Art. 12º.- Direcciones Generales y otras dependencias.
+###Art. 12º.- Direcciones Generales y otras dependencias.
 El «Ministerio» podrá incorporar en su organigrama a las Direcciones Generales o dependencias similares que considere necesarias para el cumplimiento de sus objetivos. Los Viceministerios contarán cuanto menos con las siguientes Direcciones Generales:
 1.	Viceministerio de Tecnologías de la Información y Comunicación (TIC):
 a)	Dirección General de Infraestructura y Conectividad
@@ -145,23 +145,23 @@ b)	Dirección General de Comunicación Estratégica.
 c)	Dirección General de Información Presidencial.
 d)	Dirección General de Medios del Estado.
 
-##Art. 13º.- Nombramientos.
+###Art. 13º.- Nombramientos.
 Los Viceministros, el Director General de Gabinete, el Secretario General, el Asesor Jurídico, el Auditor Interno y el Director General de Administración y Finanzas serán nombrados por decreto del Poder Ejecutivo, a propuesta del Ministro. Las personas nombradas en dichos cargos estarán sujetas a la libre disposición del Presidente de la República, conforme con la Ley de la Función Pública. 
 Los demás cargos serán nombrados por resolución del Ministro, de conformidad a lo establecido en la Ley de la Función Pública y sus reglamentaciones.
 
-##Art. 14º.- Requisitos e incompatibilidades.
+###Art. 14º.- Requisitos e incompatibilidades.
 Para ejercer los cargos de Viceministros, Secretario General, Directores Generales y Directores del «Ministerio» se requerirá, tener nacionalidad paraguaya, haber cumplido veinticinco (25) años de edad, tener probada idoneidad en la materia y cumplir con los demás requisitos establecidos en la Ley de la Función Pública que no contraríen los que se establecen en este artículo.
 Dichos cargos serán ejercidos a tiempo completo y con dedicación exclusiva y es incompatible con el ejercicio de otra actividad, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones salvo el ejercicio de la docencia a tiempo parcial y opuesto al horario laboral siempre que ella no perturbe el ejercicio de sus funciones.
 
-##Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
+###Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
 Se podrá modificar y ampliar la estructura organizacional y los niveles de dependencias del «Ministerio», y establecer las funciones y atribuciones de las mismas conforme a las competencias asignadas en la presente ley, por decreto del Poder Ejecutivo.
 
-##Art. 16º.- Patrimonio.
+###Art. 16º.- Patrimonio.
 El patrimonio del «Ministerio» está constituido por:
 1.	La totalidad del activo y pasivo de la «SENATICS» y de la «SICOM» constituidos por muebles, inmuebles, derechos, acciones, garantías o privilegios, subrogándose de pleno derecho al «Ministerio» en todas las acciones y derechos que aquellas Instituciones detentan a la fecha.
 2.	Los bienes adquiridos en el futuro para el cumplimiento de sus fines.
 
-##Art. 17º.- Recursos Económicos.
+###Art. 17º.- Recursos Económicos.
 Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
 1.	Las asignaciones y subvenciones fijadas en el Presupuesto General de la Nación (PGN) para el «Ministerio» en cada ejercicio fiscal;
 2.	Los bienes que le trasfieran el Estado paraguayo o los que adquiera legalmente a cualquier título y los frutos de tales bienes;
@@ -175,7 +175,7 @@ Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
 10.	Otros recursos que se le asignen.
 11.	Los recursos provenientes de los fondos del «FONTIC» destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de sus fines.
 
-##Art. 18º.- Absorción del «FONTIC». Componentes.  
+###Art. 18º.- Absorción del «FONTIC». Componentes.  
 El «Ministerio» absorbe como parte de sus recursos económicos, el «FONTED» el cual pasará a llamarse «FONTIC», constituido con la finalidad de lograr los objetivos vinculados con programas de Tecnología de la Información y Comunicación
 Forman parte del «FONTIC»:
 1.	Los fondos provenientes de convenios o acuerdos con instituciones nacionales o internacionales, públicas o privadas que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC».
@@ -184,54 +184,54 @@ Forman parte del «FONTIC»:
 4.	Los recursos provenientes de los Royalties y Compensaciones que corresponden a la Administración Central, de conformidad a lo establecido en el inciso a) del Artículo 1º de la Ley Nº 3984/2010, en un monto que deberá establecerse en cada Ejercicio Fiscal.
 5.	Además, podrán formar parte de los recursos del «FONTIC» las donaciones, legados, transferencias u otros aportes, por cualquier título proveniente de personas naturales o jurídicas nacionales o extranjeras, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
 
-##Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
+###Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
 Las autoridades y el personal afectado al servicio de los «OEE» y los del sector privado estarán obligados a colaborar en la expedición y facilitación de los datos e informaciones requeridas por el «Ministerio». A tal fin facilitarán al mismo cuantos informes y documentos se le soliciten en relación al ejercicio de las atribuciones del «Ministerio»; prestarán la ayuda y la cooperación que precise el mismo para el adecuado, eficiente y eficaz ejercicio de su competencia.
 
-##Art. 20º.- Adecuación Presupuestaria.	
+###Art. 20º.- Adecuación Presupuestaria.	
 El Poder Ejecutivo podrá reprogramar y adecuar las correspondientes partidas presupuestarias, en el marco del Presupuesto General de la Nación, adecuándolas a la nueva estructura dispuesta en la presente Ley. 
 
-##Art. 21º.- Coordinación. -	
+###Art. 21º.- Coordinación. -	
 A los efectos de la presente ley, el «Ministerio» coordinará con el Ministerio de Hacienda el ajuste de conciliación de las cuentas, cargos y presupuestos.
 
-##Art. 22º.- Reglamentación.
+###Art. 22º.- Reglamentación.
 La utilización de los medios electrónicos deberá ser reglamentada y deberá aplicarse conforme lo establece la legislación vigente en la materia.
 
-##Art. 23º.- Personal, bienes y recursos financieros.
+###Art. 23º.- Personal, bienes y recursos financieros.
 A partir de la vigencia de la presente ley, el personal, bienes y recursos financieros de la «SENATICS» y de la «SICOM» pasarán a formar parte del «Ministerio».  
 Todos los derechos y acciones atribuidos por leyes especiales a la «SENATICS» y a la «SICOM», quedan subrogados a favor del «Ministerio».
 A los efectos de determinar el patrimonio del «Ministerio», la «SENATICS» y la «SICOM» deberán proceder a un inventario general de los bienes, derechos y obligaciones.
 
-##Art. 24º.- Personal.
+###Art. 24º.- Personal.
 1.	El personal que, a la fecha de la promulgación de la presente ley, forme parte del anexo del personal de la «SENATICS» y de la «SICOM», pasará a formar parte de la nómina inicial del «Ministerio» y gozará de la misma antigüedad, régimen de jubilación y demás derechos adquiridos. Se regirán por esta ley, sus reglamentos, la Ley de la Función Pública, sus normas complementarias y reglamentarias.
 2.	El personal, que a la fecha de promulgación de esta ley forme parte del anexo del personal de la «SENATICS» y de la «SICOM», y que ya cumpliese con los requisitos de la jubilación ordinaria, deberá acogerse a los beneficios de la misma.
 3.	El personal contratado que se encuentre prestando servicios en la «SENATICS» y en la «SICOM», continuará prestando dichos servicios en los mismos términos y condiciones contractuales.
 4.	El Ministro del «Ministerio» podrá implementar un sistema de retiro voluntario incentivado, de acuerdo con la disponibilidad presupuestaria, para el personal que, a la fecha de la promulgación de la presente ley, desee acogerse a los beneficios de este sistema.
 
-##Art. 25º.- Facultades Especiales. Restructuración cuadro de asignación y reformulación del presupuesto.
+###Art. 25º.- Facultades Especiales. Restructuración cuadro de asignación y reformulación del presupuesto.
 1.	El Ministro del «Ministerio», queda autorizado a reestructurar el cuadro de asignación de personal y a reformular el proyecto de presupuesto correspondiente al Ejercicio Fiscal vigente, en el marco de las disposiciones legales vigentes y en concordancia con la organización establecida en la presente ley.
 2.	El Ministro del «Ministerio» será responsable de definir y aprobar el organigrama institucional, los manuales de cargos y funciones, los manuales de procedimientos y las atribuciones y procedimientos del área de coordinación mencionados en la presente ley, correspondiente al «Ministerio», en un plazo no mayor de ciento ochenta días (180) días, contados a partir de su designación.
 
-##Art. 26º.- Relaciones con «CONATEL» «COPACO» y «AEP»
+###Art. 26º.- Relaciones con «CONATEL» «COPACO» y «AEP»
 A partir de la entrada en vigencia de la presente ley, las relaciones de la Comisión Nacional de Telecomunicaciones «CONATEL» con el Poder Ejecutivo, se canalizarán a través del «Ministerio» en sustitución del Ministerio de Obras Públicas y Comunicaciones, según lo establecido en el artículo 6 de la Ley N° 642/95 “De Telecomunicaciones”.
 A partir de la entrada en vigencia de la presente Ley las relaciones de la «COPACO» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
 A partir de la entrada en vigencia de la presente Ley las relaciones de la «AEP» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
 
-##Art. 27º.- De la Integración del Consejo Nacional de Ciencia y Tecnología (CONACYT)
+###Art. 27º.- De la Integración del Consejo Nacional de Ciencia y Tecnología (CONACYT)
 El «Ministerio» integrará el Consejo Nacional de Ciencia y Tecnología (CONACYT), para lo cual el Ministro deberá designar a un representante titular y un representante suplente, los cuales serán nombrados como consejeros por Decreto del Poder Ejecutivo. 
 
-##Art. 28º.- Extinción de «SENATICS» y «SICOM».
+###Art. 28º.- Extinción de «SENATICS» y «SICOM».
 La «SENATICS» y la «SICOM» dependiente de la Presidencia de la República, quedarán extinguidas de pleno derecho a partir de la entrada en vigencia de la presente ley.
 
-##Art. 29 º.- Derogación.
+###Art. 29 º.- Derogación.
 Queda derogada la Ley Nº 4989/ 2013 «Que crea el Marco de Aplicación de las Tecnologías de la Información y Comunicación en el Sector Público y crea la Secretaría Nacional de la Tecnologías de la Información y Comunicación (SENATICS)» y todas las disposiciones contrarias a la presente Ley a partir de su entrada en vigor.
 
-##Art. 30º.- Tiempo máximo de adecuación.
+###Art. 30º.- Tiempo máximo de adecuación.
 El «Ministerio» y los demás «OEE» afectados por esta ley, deberán adecuar sus dependencias y funciones a lo establecido en la presente ley, en un plazo no mayor a doce (12) meses, contados a partir de su promulgación y publicación.
 
-##Art. 31º.- Reglamentación.
+###Art. 31º.- Reglamentación.
 El Poder Ejecutivo reglamentará la presente ley en un plazo no mayor a ciento veinte (120) días, contados a partir de su promulgación y publicación.
 
-##Art. 32º.- Vigencia.
+###Art. 32º.- Vigencia.
 La presente Ley entrará en vigencia a partir del día siguiente de la publicación en la Gaceta Oficial de la República del Paraguay.
 
-##Art. 33º.- Comuníquese al Poder Ejecutivo.
+###Art. 33º.- Comuníquese al Poder Ejecutivo.

--- a/ley_Diputados.md
+++ b/ley_Diputados.md
@@ -1,0 +1,237 @@
+“QUE CREA EL MINISTERIO DE TECNOLOGÍAS DE LA INFORMACIÓN Y COMUNICACIÓN Y ESTABLECE SU CARTA ORGÁNICA”
+
+--------------------------------------
+
+EL CONGRESO DE LA NACIÓN PARAGUAYA SANCIONA CON FUERZA DE
+
+# L E Y: MITIC
+
+##Art. 1º.- Objeto.  
+La presente ley tiene por objeto crear el Ministerio de Tecnologías de la Información y Comunicación, en adelante el «Ministerio», identificado con las siglas «MITIC», en sustitución de la Secretaría Nacional de Tecnologías de la Información y Comunicación «SENATICS» y de la Secretaría de Información y Comunicación para el Desarrollo «SICOM», y establecer su carta orgánica y funciones, así como los órganos que lo conforman.
+
+##Art. 2º.- 
+El «Ministerio» es un órgano del Poder Ejecutivo, de derecho público. Se constituye en la entidad técnica e instancia rectora, normativa, estratégica y de gestión especializada, para formulación de políticas e implementación de planes y proyectos en el ámbito de las Tecnologías de la Información y Comunicación en el sector público, y de la comunicación del Poder Ejecutivo tanto en su aspecto social como educativo para la inclusión, apropiación e innovación en la creación, uso e implementación de las tecnologías.
+
+##Art. 3º.- 
+El «Ministerio» constituye su domicilio legal en la ciudad de Asunción, pudiendo establecer oficinas regionales, departamentales y distritales. 
+Toda acción judicial en la que el «Ministerio» sea parte deberá iniciarse única y exclusivamente ante los Juzgados y Tribunales de la circunscripción judicial de la Capital de la República, salvo que el «Ministerio» acepte expresamente someterse a otra jurisdicción, en ese caso se podrá constituir otros domicilios procesales.
+
+##Art. 4º.- 
+Principios Generales.
+Toda actuación relacionada con la presente ley debe observar los siguientes principios generales:                         
+**1.	Planificación.** Las políticas públicas que se apliquen deben originarse en un adecuado diagnóstico de la situación y servir de base para la planificación de las estrategias, objetivos, metas y acciones que serán emprendidas por el «Ministerio» en sus diferentes ámbitos de actuación.                                                                                                                     
+**2.	Transparencia y Participación Ciudadana.** Los procesos, requisitos y políticas aplicables serán de conocimiento público y se fomentará la difusión de toda información a través de la cual la ciudadanía pueda participar con sus opiniones, demandas y propuestas.                                                                                                                                                                                         
+**3.	Fomento de las TIC.** La investigación, el fomento, la promoción y el desarrollo de las Tecnologías de la Información y Comunicación son una política de Estado que involucra a todos los sectores y niveles de la administración pública y de la sociedad, para contribuir de manera eficiente y eficaz al desarrollo educativo, cultural, económico, industrial, social y político, e incrementar la productividad, la competitividad, el respeto a los derechos humanos inherentes y la inclusión social.                                                                                                                                               
+**4.	Protección de los derechos de los usuarios.** El Estado velará por la adecuada protección de los derechos de los usuarios de las Tecnologías de la Información y Comunicación, en los niveles de calidad establecidos dentro de los rangos que certifiquen las entidades competentes e idóneas en la materia; brindando información clara, transparente, veraz y oportuna para que los usuarios tomen sus decisiones.                                                                                                                                                        
+**5.	Libre Adopción Tecnológica.** El Estado garantizará la libre adopción de tecnologías por parte de los habitantes del territorio nacional, y los Organismos y Entidades del Estado lo adoptarán a través de los lineamientos del Plan Director de Tecnologías de la Información y Comunicación, que permitan fomentar la eficiente prestación de servicios, contenidos y aplicaciones que utilicen Tecnologías de la Información y Comunicación, para garantizar la libertad de uso por parte de los habitantes del territorio nacional, de manera que su adopción sea a su vez armónica con el desarrollo  sostenible.                                           
+**6.	Masificación del Gobierno Electrónico.** Con el fin de lograr la prestación de servicios eficientes a todos los sectores de la sociedad, las entidades públicas deberán adoptar todas las medidas necesarias para garantizar el máximo aprovechamiento de las Tecnologías de la Información y Comunicación en el desarrollo de sus funciones. El Gobierno Nacional fijará los mecanismos y condiciones para garantizar el desarrollo de este principio. Y en la reglamentación correspondiente, establecerá los plazos, términos y prescripciones, no solamente para la instalación de las infraestructuras indicadas y necesarias, sino también para mantener actualizadas y con la información completa, los medios e instrumentos tecnológicos.
+
+##Art. 5º.- Glosario
+A los efectos de la presente ley, se entenderá por:
+**1.	«MITIC»:** Ministerio de Tecnologías de la Información y Comunicación.
+**2.	«OEE»:** Organismos y Entidades del Estado.
+**3.	«SENATICS»:** Secretaría Nacional de Tecnologías de la Información y Comunicación.
+**4.	«SICOM»:** Secretaría de Información y Comunicación para el Desarrollo. 
+**5.	«TIC»:** Tecnologías de la Información y Comunicación. 
+**6.	«FONTIC»:** Fondo Nacional de Tecnologías de la Información y Comunicación 
+**7.	«CONATEL»:** Comisión Nacional de Telecomunicaciones.
+**8.	«COPACO»:** Compañía Paraguaya de Comunicaciones S.A.
+**9.	«AEP»:** Agencia Espacial del Paraguay.
+**10. «IID»:** Investigación, Innovación y Desarrollo
+
+##Art. 6º.- Objetivos del Ministerio.
+El «Ministerio» tendrá los siguientes objetivos:
+**1.**	Elaborar, promover, implementar y supervisar las políticas públicas, planes, programas y proyectos del sector de las Tecnologías de la Información y la Comunicación y de sectores convergentes, así como su ordenamiento general, en concordancia con la Constitución de la República del Paraguay y las leyes.
+**2.**	Promover, incrementar y facilitar el uso de las «TIC», buscando siempre la participación y el acceso efectivo en igualdad de oportunidades a todos los habitantes de la República, con la mayor cobertura y calidad de servicios posibles; así como propiciar el uso eficiente de las redes informáticas, la IID, formación del talento humano y la competencia a nivel nacional e internacional. 
+**3.**	Impulsar el desarrollo y el fortalecimiento del sector, la innovación tecnológica, economía digital, mediante políticas públicas que involucren a todos los niveles de los «OEE» y de la sociedad.
+**4.**	Desarrollar procesos y estrategias de Comunicación para la difusión de la información que generen los «OEE» y la parte paraguaya de los Organismos Binacionales o Multilaterales, de manera a lograr que la difusión de la información sea realizada en forma ágil y oportuna e incentivando la apropiación social y educativa de las tecnologías para implementación adecuada, una interacción comunicacional participativa, plural y transparente entre el Poder Ejecutivo y los habitantes de la República del Paraguay.
+
+##Art. 7º.- Competencias.
+El «Ministerio», tendrá las siguientes competencias: 
+**1.**	Diseñar, planificar, adoptar, ejecutar y promover las políticas, planes, programas y proyectos del sector de las Tecnologías de la Información y Comunicación que contribuyan al mejoramiento de la calidad de vida de las comunidades, el acceso a las nuevas tecnologías y a la información de manera a contribuir a generar oportunidades de educación, trabajo, salud, justicia, cultura y recreación, entre otras.
+**2.**	Establecer y gestionar políticas de protección de la información personal y gubernamental, y cultivar los conocimientos sobre la industria de seguridad de la información, para lo cual deberá establecer un sistema de organización de seguridad, proponer una política de seguridad a nivel nacional, y establecer un plan de integración de protección de información.
+**3.**	Promover iniciativas que contribuyan a la construcción de un ecosistema digital seguro, confiable y resiliente, incluyendo el sector público, privado, academia y ciudadanía. 
+**4.**	Coordinar la ejecución de acciones conjuntas e integradas entre las distintas reparticiones públicas, de actividades relacionadas con la integración de los servicios públicos, ciberseguridad, el desarrollo de la normalización y la sistematización y difusión de la información de acciones relacionadas con la gestión pública por medios electrónicos 
+**5.**	Propiciar y emitir directrices para la optimización de los trámites y procesos, y la interoperabilidad entre los distintos Organismos y Entidades del Estado, a su vez diseñar, coordinar, y monitorear las políticas públicas, planes y estrategias a ser ejecutadas por los mismos, en el marco del Gobierno Electrónico y de Ciberseguridad. 
+**6.**	Implementar y administrar la infraestructura tecnológica vinculada con redes públicas y centro de datos del Poder Ejecutivo. 
+**7.**	Orientar, priorizar y dirigir el proceso de incorporación y mantenimiento de las Tecnologías de la Información y Comunicación (TIC) en la gestión pública, definiendo los diversos componentes, etapas y secuencias del proceso que deben ser implementados por los Organismos y Entidades del Estado, que tengan incidencia directa en el fortalecimiento de la eficacia, eficiencia y transparencia de las prestaciones y servicios públicos. 
+**8.**	Aprobar y apoyar los planes, proyectos y actividades ejecutadas por los Organismos y Entidades del Estado, en el cumplimiento de sus fines, vinculados al sector de TIC. 
+**9.**	Supervisar el sistema de compras públicas en todo lo que se refiera a la incorporación tecnológica para las instituciones del Estado, a fin de garantizar la adquisición de herramientas adecuadas, eficaces, eficientes y de bajo costo. Asesorar y responder a las consultas técnicas de las distintas entidades del Estado y de la Dirección Nacional de Contrataciones Públicas referidas a las compras públicas de equipamientos, sistemas, softwares en las materias de su competencia. 
+**10.**	Promover estudios y evaluaciones para la implementación de software y programas eficientes y útiles, que promuevan la inclusión digital, la integración y la disminución de la brecha digital, tomando como referencia el uso de software con licenciamiento libre. Promover el desarrollo de infraestructura física, plataformas tecnológicas, redes y sistemas comunes e integrados que faciliten la gestión interactiva. 
+**11.**	Promover y coordinar la construcción, operación y mantenimiento de una Red Nacional Integrada de Infraestructuras necesarias para las «TIC», como ser redes de fibra óptica, medios de difusión públicos, sistemas de comunicaciones utilizando el espectro radioeléctrico y sistemas satelitales. 
+**12.**	Promover iniciativas, desarrollar actividades conducentes al mejor conocimiento, desarrollo y aplicación de las tecnologías en las comunidades del país y en la gestión pública; desarrollar recursos humanos idóneos para la implementación de los programas y proyectos de incorporación tecnológica; en coordinación con el sector empresarial, academia y demás organismos afines. 
+**13.**	Dictar, asesorar y participar en la formulación de las políticas nacionales en todas aquellas materias relacionadas con la protección de la información personal y gubernamental; el uso de tecnologías en la educación, en materia de ciberseguridad, Innovación productiva, economía digital y demás sectores convergentes de las TIC. 
+**14.**	Definir las mejores tecnologías y especificar los equipos, programas y medios de conectividad, para las instituciones educativas definidas por el Ministerio de Educación. 
+**15.**	Fomentar la permanente alianza público privada en el desarrollo del sector tecnológico para el cumplimiento de sus fines. 
+**16.**	Gestionar la cooperación internacional en apoyo al desarrollo del sector las Comunicaciones y de las «TIC» en la República del Paraguay y coordinar con las demás instituciones del Estado la representación internacional de la República del Paraguay en el campo de las «TIC», especialmente ante los organismos internacionales del sector.
+**17.**	Convocar y presidir el Comité de Coordinación e Interoperabilidad para el Gobierno Electrónico. 
+**18.**	Diseñar y desplegar estrategias comunicacionales y de información que vinculen a los diferentes «OEE» con la sociedad y promueva la interacción de una comunicación participativa, plural y transparente a través del uso eficiente de las diferentes formas de comunicación.
+**19.**	Asesorar y prestar asistencia técnica a entidades estatales, privadas, organizaciones civiles, gobiernos departamentales y municipales, a solicitud de los mismos; así como también promover y coordinar con ellos las iniciativas que guarden relación con los fines de esta ley.
+**20.**	Implementar estrategias de supervisión y fiscalización en la ejecución de los proyectos ejecutados en el marco de los programas y planes del «Ministerio», así como ejercer facultades de verificación y control en todo lo concerniente a tecnologías de la información y de la comunicación, realizadas por los «OEE».  
+**21.**	Ejercer la autoridad de administración de los fondos del «FONTIC» destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de sus fines. 
+**22.**	Ejercer las demás competencias que le confiere la presente ley, las que fuesen establecidas por leyes especiales y las establecidas en la reglamentación correspondiente.
+**23.**	Ejercer como Autoridad de Ciberseguridad, y de prevención, gestión y control de incidentes cibernéticos que pongan en riesgo el ecosistema digital naciona
+**24.**	Definir y designar los sistemas, procesos y tecnologías de información que serán considerados Infraestructura TICs crítica para el funcionamiento del Estado Paraguayo
+**25.**	Salvaguardar la efectiva capacidad de gestión de la infraestructura TICs crítica para el funcionamiento del Estado Paraguayo.
+
+##Art. 8º.- El Ministro. 
+El Ministro es la máxima autoridad institucional. En tal carácter es el responsable de la dirección y de la gestión especializada, técnica, financiera y administrativa de la Entidad, en el ámbito de sus atribuciones legales, asimismo, ejerce la representación legal del «Ministerio».
+
+##Art. 9º.- Nombramiento, requisitos, incompatibilidades e inmunidades.
+El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los siguientes requisitos:
+**1.**	Ser paraguayo natural; 
+**2.**	Haber cumplido veinticinco (25) años de edad; 
+**3.**	Tener probada idoneidad técnica y amplia experiencia en el sector de las Tecnologías de la Información y Comunicación.
+**4.**	Estar en pleno goce de los derechos civiles y políticos. No registrar antecedentes de mal desempeño en la función pública.
+**5.**	La función de Ministro es incompatible con el ejercicio de otra actividad o cargo público o privado, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones, salvo el ejercicio de la docencia.
+
+##Art. 10º.- Deberes y atribuciones.
+Son deberes y atribuciones del Ministro:
+1.	Ejercer la dirección, administración, supervisión y control del «Ministerio», tomando las decisiones que estime necesarias para la buena gestión del mismo.
+2.	Elaborar y ejecutar los programas, proyectos, planes y políticas generales del «Ministerio».
+3.	Ejercer la representación legal del «Ministerio», pudiendo igualmente otorgar poderes generales y especiales para actuaciones judiciales y administrativas.
+4.	Velar por el cumplimiento de las normas aplicables al «Ministerio» y adoptar las medidas necesarias para asegurar su normal funcionamiento.
+5.	Asumir la representación como máxima y exclusiva autoridad en cuestiones de políticas y acciones de las Tecnologías de la Información y de Comunicación.
+6.	Elaborar el anteproyecto de presupuesto del «Ministerio» y someterlo al órgano ministerial competente en los plazos legales previstos y acompañar su estudio hasta su promulgación, y ejecutarlo conforme con la planificación anual.
+7.	Integrar el Consejo de Ministros con voz y voto; informar al mismo de la marcha de sus actividades, coordinar las mismas con los demás ministerios, y aplicar las decisiones que surjan del mismo.
+8.	Dirigir las actividades del «Ministerio» e impartir las instrucciones correspondientes.
+9.	Ejercer la potestad reglamentaria en los términos previstos en esta ley y el decreto reglamentario. Aprobar el reglamento interno y el manual operativo.
+10.	Organizar la estructura del «Ministerio» y modificarla sin que el ejercicio de esta facultad signifique modificar la estructura de la misma establecida en esta ley y su decreto reglamentario.
+11.	Aceptar donaciones, legados y recursos provenientes de cooperación técnica nacional e internacional, conforme a las disposiciones constitucionales y legales pertinentes para la consecución de los objetivos del «Ministerio».
+12.	Nombrar, remover, trasladar y comisionar a los funcionarios administrativos del «Ministerio», de conformidad con lo establecido en la legislación respectiva.
+13.	 Solicitar el nombramiento y remoción de los Viceministros y de los Directores Generales del «Ministerio», de conformidad a lo establecido en la ley de la función pública.
+14.	Administrar los fondos previstos en el Presupuesto General de la Nación y demás recursos establecidos en esta ley, ejerciendo la función de ordenador de gastos.
+15.	Celebrar los contratos o convenios, con instituciones nacionales, binacionales o internacionales que estime necesarios para el cumplimiento de los objetivos y fines del «Ministerio», conforme a los requisitos establecidos por la ley.
+16.	Asesorar e informar al Poder Ejecutivo en los asuntos propios de la competencia del «Ministerio», cuando aquél lo requiera.
+17.	Coordinar y mantener las relaciones del «Ministerio» con los organismos similares de otros países y entidades extranjeras, en las materias que le son propias.
+18.	Dictar las reglamentaciones que fueren necesarias para el ejercicio de sus atribuciones.
+19.	Elevar al Poder Ejecutivo la propuesta de creación, modificación, ampliación, abrogación o derogación de leyes, decretos o normativas en ejercicio de su competencia.
+20.	Diseñar, implementar y supervisar la aplicación de las políticas de las Tecnologías de la Información y Comunicación en los programas y proyectos del Poder Ejecutivo, de acuerdo con las normativas legales vigentes.
+21.	Diseñar las estrategias y acuerdos necesarios para el desarrollo de trabajos participativos con las organizaciones civiles.
+22.	Obtener, gestionar, y administrar los recursos asignados para los fines específicos de la presente ley y los fondos creados para el sector, así como el cuidado de los bienes o patrimonio de la institución.
+23.	Suscribir convenios, acuerdos y otras formas de cooperación en materia de temas de Tecnologías de la Información y Comunicación, que propicie la investigación e intercambio de conocimientos y experiencias, y movilice además los recursos nacionales y externos para la ejecución de planes y programas relacionados al sector de las «TIC» y la Comunicación.
+24.	Administrar los fondos destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de los fines del «Ministerio».
+25.	Propiciar y realizar todo tipo de estudios, análisis y reglamentaciones referidas al sector de las Tecnologías de la Información y Comunicación.
+26.	Resolver los recursos administrativos que se interpongan ante él, de conformidad a la ley.
+27.	Ejercer las demás atribuciones y funciones que le confiere la presente ley y los reglamentos del Poder Ejecutivo.
+28.	Realizar los demás actos necesarios para el mejor cumplimiento de los fines y objetivos del «Ministerio»;
+29.	Las demás funciones que fuesen establecidas por leyes especiales o aquellas necesarias para el correcto funcionamiento del «Ministerio»; y,
+30.	Cumplir y hacer cumplir la presente ley, su reglamentación y las demás disposiciones conexas.
+
+##Art. 11º.- Estructura Orgánica. -
+El «Ministerio» contará con la siguiente estructura orgánica:
+a)	Ministro;
+b)	Dirección General de Gabinete Ministerial;
+c)	Secretaria General; 
+d)	Viceministerio de Tecnologías de la Información y Comunicación (TIC);
+e)	Viceministerio de Comunicación
+f)	Dirección General de Asesoría Jurídica;
+g)	Dirección General de Administración y Finanzas;
+h)	Auditoría Interna; y,
+i)	Otras Direcciones Generales y dependencias que fueren necesarias para el cumplimiento de los objetivos del «Ministerio».
+En caso de sustitución del Ministro, los cargos de los titulares de las unidades orgánicas detalladas en el presente artículo, estarán a disposición de la nueva autoridad designada por el Poder Ejecutivo, pudiendo ser reasignados según necesidad o destituidos sin más trámites por término de funciones.
+
+##Art. 12º.- Direcciones Generales y otras dependencias.
+El «Ministerio» podrá incorporar en su organigrama a las Direcciones Generales o dependencias similares que considere necesarias para el cumplimiento de sus objetivos. Los Viceministerios contarán cuanto menos con las siguientes Direcciones Generales:
+1.	Viceministerio de Tecnologías de la Información y Comunicación (TIC):
+a)	Dirección General de Infraestructura y Conectividad
+b)	Dirección General de Gobierno Electrónico.
+c)	Dirección General de Inclusión Digital y TIC en la Educación
+d) Dirección General de Innovación Productiva y Economía Digital
+e) Dirección General de Ciberseguridad y Protección de la Información 
+2.	Viceministerio de Comunicación:
+a)	Dirección General de Educación y Comunicación para el Bienestar.
+b)	Dirección General de Comunicación Estratégica.
+c)	Dirección General de Información Presidencial.
+d)	Dirección General de Medios del Estado.
+
+##Art. 13º.- Nombramientos.
+Los Viceministros, el Director General de Gabinete, el Secretario General, el Asesor Jurídico, el Auditor Interno y el Director General de Administración y Finanzas serán nombrados por decreto del Poder Ejecutivo, a propuesta del Ministro. Las personas nombradas en dichos cargos estarán sujetas a la libre disposición del Presidente de la República, conforme con la Ley de la Función Pública. 
+Los demás cargos serán nombrados por resolución del Ministro, de conformidad a lo establecido en la Ley de la Función Pública y sus reglamentaciones.
+
+##Art. 14º.- Requisitos e incompatibilidades.
+Para ejercer los cargos de Viceministros, Secretario General, Directores Generales y Directores del «Ministerio» se requerirá, tener nacionalidad paraguaya, haber cumplido veinticinco (25) años de edad, tener probada idoneidad en la materia y cumplir con los demás requisitos establecidos en la Ley de la Función Pública que no contraríen los que se establecen en este artículo.
+Dichos cargos serán ejercidos a tiempo completo y con dedicación exclusiva y es incompatible con el ejercicio de otra actividad, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones salvo el ejercicio de la docencia a tiempo parcial y opuesto al horario laboral siempre que ella no perturbe el ejercicio de sus funciones.
+
+##Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
+Se podrá modificar y ampliar la estructura organizacional y los niveles de dependencias del «Ministerio», y establecer las funciones y atribuciones de las mismas conforme a las competencias asignadas en la presente ley, por decreto del Poder Ejecutivo.
+
+##Art. 16º.- Patrimonio.
+El patrimonio del «Ministerio» está constituido por:
+1.	La totalidad del activo y pasivo de la «SENATICS» y de la «SICOM» constituidos por muebles, inmuebles, derechos, acciones, garantías o privilegios, subrogándose de pleno derecho al «Ministerio» en todas las acciones y derechos que aquellas Instituciones detentan a la fecha.
+2.	Los bienes adquiridos en el futuro para el cumplimiento de sus fines.
+
+##Art. 17º.- Recursos Económicos.
+Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
+1.	Las asignaciones y subvenciones fijadas en el Presupuesto General de la Nación (PGN) para el «Ministerio» en cada ejercicio fiscal;
+2.	Los bienes que le trasfieran el Estado paraguayo o los que adquiera legalmente a cualquier título y los frutos de tales bienes;
+3.	Los ingresos o recaudaciones provenientes del cobro de los aranceles percibidos por los servicios que preste, y por los permisos y concesiones de bienes y servicios que otorgue;
+4.	Los intereses, tasas o reajustes que se le acrediten en instituciones bancarias y financieras donde deposite haberes; 
+5.	Las sumas y bienes que le transfieran los gobiernos departamentales y municipales para financiar los planes y programas de inversión acordados con los mismos; 
+6.	Las donaciones, legados y otras contribuciones de personas naturales y jurídicas, nacionales y extranjeras;
+7.	Los fondos provenientes de convenios o acuerdos con entidades binacionales, instituciones nacionales, internacionales públicas o privadas que celebre el «Ministerio»;
+8.	Las rentas de bienes patrimoniales;
+9.	Los recursos que se le transfieran conforme a la ley; 
+10.	Otros recursos que se le asignen.
+11.	Los recursos provenientes de los fondos del «FONTIC» destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de sus fines.
+
+##Art. 18º.- Absorción del «FONTIC». Componentes.  
+El «Ministerio» absorbe como parte de sus recursos económicos, el «FONTED» el cual pasará a llamarse «FONTIC», constituido con la finalidad de lograr los objetivos vinculados con programas de Tecnología de la Información y Comunicación
+Forman parte del «FONTIC»:
+1.	Los fondos provenientes de convenios o acuerdos con instituciones nacionales o internacionales, públicas o privadas que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC».
+2.	Los recursos provenientes de la cooperación técnica internacional, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
+3.	El cincuenta por ciento (50 %) de los recursos afectados al Fondo de Servicios Universales, administrado por la Comisión Nacional de Telecomunicaciones «CONATEL».
+4.	Los recursos provenientes de los Royalties y Compensaciones que corresponden a la Administración Central, de conformidad a lo establecido en el inciso a) del Artículo 1º de la Ley Nº 3984/2010, en un monto que deberá establecerse en cada Ejercicio Fiscal.
+5.	Además, podrán formar parte de los recursos del «FONTIC» las donaciones, legados, transferencias u otros aportes, por cualquier título proveniente de personas naturales o jurídicas nacionales o extranjeras, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
+
+##Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
+Las autoridades y el personal afectado al servicio de los «OEE» y los del sector privado estarán obligados a colaborar en la expedición y facilitación de los datos e informaciones requeridas por el «Ministerio». A tal fin facilitarán al mismo cuantos informes y documentos se le soliciten en relación al ejercicio de las atribuciones del «Ministerio»; prestarán la ayuda y la cooperación que precise el mismo para el adecuado, eficiente y eficaz ejercicio de su competencia.
+
+##Art. 20º.- Adecuación Presupuestaria.	
+El Poder Ejecutivo podrá reprogramar y adecuar las correspondientes partidas presupuestarias, en el marco del Presupuesto General de la Nación, adecuándolas a la nueva estructura dispuesta en la presente Ley. 
+
+##Art. 21º.- Coordinación. -	
+A los efectos de la presente ley, el «Ministerio» coordinará con el Ministerio de Hacienda el ajuste de conciliación de las cuentas, cargos y presupuestos.
+
+##Art. 22º.- Reglamentación.
+La utilización de los medios electrónicos deberá ser reglamentada y deberá aplicarse conforme lo establece la legislación vigente en la materia.
+
+##Art. 23º.- Personal, bienes y recursos financieros.
+A partir de la vigencia de la presente ley, el personal, bienes y recursos financieros de la «SENATICS» y de la «SICOM» pasarán a formar parte del «Ministerio».  
+Todos los derechos y acciones atribuidos por leyes especiales a la «SENATICS» y a la «SICOM», quedan subrogados a favor del «Ministerio».
+A los efectos de determinar el patrimonio del «Ministerio», la «SENATICS» y la «SICOM» deberán proceder a un inventario general de los bienes, derechos y obligaciones.
+
+##Art. 24º.- Personal.
+1.	El personal que, a la fecha de la promulgación de la presente ley, forme parte del anexo del personal de la «SENATICS» y de la «SICOM», pasará a formar parte de la nómina inicial del «Ministerio» y gozará de la misma antigüedad, régimen de jubilación y demás derechos adquiridos. Se regirán por esta ley, sus reglamentos, la Ley de la Función Pública, sus normas complementarias y reglamentarias.
+2.	El personal, que a la fecha de promulgación de esta ley forme parte del anexo del personal de la «SENATICS» y de la «SICOM», y que ya cumpliese con los requisitos de la jubilación ordinaria, deberá acogerse a los beneficios de la misma.
+3.	El personal contratado que se encuentre prestando servicios en la «SENATICS» y en la «SICOM», continuará prestando dichos servicios en los mismos términos y condiciones contractuales.
+4.	El Ministro del «Ministerio» podrá implementar un sistema de retiro voluntario incentivado, de acuerdo con la disponibilidad presupuestaria, para el personal que, a la fecha de la promulgación de la presente ley, desee acogerse a los beneficios de este sistema.
+
+##Art. 25º.- Facultades Especiales. Restructuración cuadro de asignación y reformulación del presupuesto.
+1.	El Ministro del «Ministerio», queda autorizado a reestructurar el cuadro de asignación de personal y a reformular el proyecto de presupuesto correspondiente al Ejercicio Fiscal vigente, en el marco de las disposiciones legales vigentes y en concordancia con la organización establecida en la presente ley.
+2.	El Ministro del «Ministerio» será responsable de definir y aprobar el organigrama institucional, los manuales de cargos y funciones, los manuales de procedimientos y las atribuciones y procedimientos del área de coordinación mencionados en la presente ley, correspondiente al «Ministerio», en un plazo no mayor de ciento ochenta días (180) días, contados a partir de su designación.
+
+##Art. 26º.- Relaciones con «CONATEL» «COPACO» y «AEP»
+A partir de la entrada en vigencia de la presente ley, las relaciones de la Comisión Nacional de Telecomunicaciones «CONATEL» con el Poder Ejecutivo, se canalizarán a través del «Ministerio» en sustitución del Ministerio de Obras Públicas y Comunicaciones, según lo establecido en el artículo 6 de la Ley N° 642/95 “De Telecomunicaciones”.
+A partir de la entrada en vigencia de la presente Ley las relaciones de la «COPACO» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
+A partir de la entrada en vigencia de la presente Ley las relaciones de la «AEP» con el Poder Ejecutivo, se canalizarán a través del «Ministerio».
+
+##Art. 27º.- De la Integración del Consejo Nacional de Ciencia y Tecnología (CONACYT)
+El «Ministerio» integrará el Consejo Nacional de Ciencia y Tecnología (CONACYT), para lo cual el Ministro deberá designar a un representante titular y un representante suplente, los cuales serán nombrados como consejeros por Decreto del Poder Ejecutivo. 
+
+##Art. 28º.- Extinción de «SENATICS» y «SICOM».
+La «SENATICS» y la «SICOM» dependiente de la Presidencia de la República, quedarán extinguidas de pleno derecho a partir de la entrada en vigencia de la presente ley.
+
+##Art. 29 º.- Derogación.
+Queda derogada la Ley Nº 4989/ 2013 «Que crea el Marco de Aplicación de las Tecnologías de la Información y Comunicación en el Sector Público y crea la Secretaría Nacional de la Tecnologías de la Información y Comunicación (SENATICS)» y todas las disposiciones contrarias a la presente Ley a partir de su entrada en vigor.
+
+##Art. 30º.- Tiempo máximo de adecuación.
+El «Ministerio» y los demás «OEE» afectados por esta ley, deberán adecuar sus dependencias y funciones a lo establecido en la presente ley, en un plazo no mayor a doce (12) meses, contados a partir de su promulgación y publicación.
+
+##Art. 31º.- Reglamentación.
+El Poder Ejecutivo reglamentará la presente ley en un plazo no mayor a ciento veinte (120) días, contados a partir de su promulgación y publicación.
+
+##Art. 32º.- Vigencia.
+La presente Ley entrará en vigencia a partir del día siguiente de la publicación en la Gaceta Oficial de la República del Paraguay.
+
+##Art. 33º.- Comuníquese al Poder Ejecutivo.

--- a/ley_SENATIC.md
+++ b/ley_SENATIC.md
@@ -10,7 +10,7 @@ EL CONGRESO DE LA NACIÓN PARAGUAYA SANCIONA CON FUERZA DE LEY:
 La presente ley tiene por objeto crear el Ministerio de Tecnologías de la Información y Comunicación, en adelante el «Ministerio», identificado con las siglas «MITIC», en sustitución de la Secretaría Nacional de Tecnologías de la Información y Comunicación «SENATICS» y establecer su carta orgánica y funciones, así como los órganos que lo conforman.
 
 ### Art. 2º.  
-El «Ministerio» es un órgano del Poder Ejecutivo, de derecho público, el cual se constituye en la entidad técnica especializada para la formulación de políticas públicas que regirán el sector de las Tecnologías de la Información y Comunicación, además de definir la normativa, la regulación, la definición de estrategias, de gestión especializada que incluya el ordenamiento general, el régimen de competencia, la protección al usuario, así como lo concerniente a la cobertura, calidad de servicio, promoción de la inversión y desarrollo de estas tecnologías, la planificación y uso eficiente de las redes y del espectro radioeléctrico, donde se tendrá en cuenta aspectos sociales como educativos facilitando el libre acceso sin discriminación para que los habitantes del territorio de la república accedan a la Sociedad del Conocimiento.
+El «Ministerio» es un órgano del Poder Ejecutivo, de derecho público, el cual se constituye en la entidad técnica especializada para la formulación de políticas públicas que regirán el sector de las «TIC», además de definir la normativa, la regulación, la definición de estrategias, de gestión especializada que incluya el ordenamiento general, el régimen de competencia, la protección al usuario, así como lo concerniente a la cobertura, calidad de servicio, promoción de la inversión y desarrollo de estas tecnologías, la planificación y uso eficiente de las redes y del espectro radioeléctrico, donde se tendrá en cuenta aspectos sociales como educativos facilitando el libre acceso sin discriminación para que los habitantes del territorio de la república accedan a la Sociedad del Conocimiento.
 
 ### Art. 3º. 
 El «Ministerio» constituye su domicilio legal en la ciudad de Asunción, pudiendo establecer oficinas regionales, departamentales y distritales.
@@ -25,15 +25,15 @@ Toda actuación relacionada con la presente ley debe observar los siguientes pri
 
 **2. Transparencia y Participación Ciudadana.** Los procesos, requisitos y políticas aplicables serán de conocimiento público y se fomentará la difusión de toda información a través de la cual la ciudadanía pueda participar con sus opiniones, demandas y propuestas.
 
-**3. Fomento de las TIC.** La investigación, el fomento, la promoción y el desarrollo de las Tecnologías de la Información y Comunicación son una política de Estado que involucra a todos los sectores y niveles de la administración pública y de la sociedad, para contribuir de manera eficiente y eficaz al desarrollo educativo, cultural, económico, industrial, social y político, e incrementar la productividad, la competitividad, el respeto a los derechos humanos inherentes y la inclusión social.
+**3. Fomento de las TIC.** La investigación, el fomento, la promoción y el desarrollo de las «TIC» son una política de Estado que involucra a todos los sectores y niveles de la administración pública y de la sociedad, para contribuir de manera eficiente y eficaz al desarrollo educativo, cultural, económico, industrial, social y político, e incrementar la productividad, la competitividad, el respeto a los derechos humanos inherentes y la inclusión social.
 
-**4. Protección de los derechos de los usuarios.** El Estado velará por la adecuada protección de los derechos de los usuarios de las Tecnologías de la Información y Comunicación, en los niveles de calidad establecidos dentro de los rangos que certifiquen las entidades competentes e idóneas en la materia; brindando información clara, transparente, veraz y oportuna para que los usuarios tomen sus decisiones.
+**4. Protección de los derechos de los usuarios.** El Estado velará por la adecuada protección de los derechos de los usuarios de las «TIC», en los niveles de calidad establecidos dentro de los rangos que certifiquen las entidades competentes e idóneas en la materia; brindando información clara, transparente, veraz y oportuna para que los usuarios tomen sus decisiones.
 
-**5. Neutralidad Tecnológica.** El Estado garantizará la libre adopción de tecnologías por parte de los habitantes del territorio nacional, teniendo en cuenta demostradas mejores prácticas del mercado, ademas de aplicar conceptos y normativas estandarizadas de reconocidos organismos internacionales especializados en tecnologías, que permitan fomentar la eficiente prestación de servicios, contenidos y aplicaciones que usen Tecnología de la Información y Comunicación para garantizar la libre y leal competencia, y que su adopción sea armónica con el desarrollo ambiental sostenible.
+**5. Neutralidad Tecnológica.** El Estado garantizará la libre adopción de tecnologías por parte de los habitantes del territorio nacional, teniendo en cuenta demostradas mejores prácticas del mercado, ademas de aplicar conceptos y normativas estandarizadas de reconocidos organismos internacionales especializados en tecnologías, que permitan fomentar la eficiente prestación de servicios, contenidos y aplicaciones que usen «TIC» para garantizar la libre y leal competencia, y que su adopción sea armónica con el desarrollo ambiental sostenible.
 
 **6. Códigos, Datos y formatos libre y abierto.** El Estado definirá planes de adopción de herramientas basadas en código libre y abierto, adoptando formatos libres y abiertos para la exposición de datos que se definan como de uso público. Los servicios expuestos tanto internamente en las instituciones como los expuestos a Internet estaran basados en estandares que sean soportados por dichas herramientas. Se aplicará esquemas de transparencia activa en toda la infraestructura básica, como en los sistemas y servicios de todos los organismos públicos.
 
-**7. Masificación del Gobierno Electrónico.** Con el fin de lograr la prestación de servicios eficientes a todos los sectores de la sociedad, las entidades públicas deberán adoptar todas las medidas necesarias para garantizar el máximo aprovechamiento de las Tecnologías de la Información y Comunicación en el desarrollo de sus funciones. El Gobierno Nacional fijará los mecanismos y condiciones para garantizar el desarrollo de este principio. Y en la reglamentación correspondiente, establecerá los plazos, términos y prescripciones, no solamente para la instalación de las infraestructuras indicadas y necesarias, sino también para mantener actualizadas y con la información completa, los medios e instrumentos tecnológicos.
+**7. Masificación del Gobierno Electrónico.** Con el fin de lograr la prestación de servicios eficientes a todos los sectores de la sociedad, las entidades públicas deberán adoptar todas las medidas necesarias para garantizar el máximo aprovechamiento de las «TIC» en el desarrollo de sus funciones. El Gobierno Nacional fijará los mecanismos y condiciones para garantizar el desarrollo de este principio. Y en la reglamentación correspondiente, establecerá los plazos, términos y prescripciones, no solamente para la instalación de las infraestructuras indicadas y necesarias, sino también para mantener actualizadas y con la información completa, los medios e instrumentos tecnológicos.
 
 ### Art. 5º. Glosario
 
@@ -45,37 +45,37 @@ A los efectos de la presente ley, se entenderá por:
 
 3. «SENATICS»: Secretaría Nacional de Tecnologías de la Información y Comunicación.
 
-4. «SICOM»: Secretaría de Información y Comunicación para el Desarrollo.
+4. «TIC»: Tecnologías de la Información y Comunicación.
 
-5. «TIC»: Tecnologías de la Información y Comunicación.
+5. «FONTIC»: Fondo Nacional de Tecnologías de la Información y Comunicación
 
-6. «FONTIC»: Fondo Nacional de Tecnologías de la Información y Comunicación
+6. «CONATEL»: Comisión Nacional de Telecomunicaciones.
 
-7. «CONATEL»: Comisión Nacional de Telecomunicaciones.
+7. «COPACO»: Compañía Paraguaya de Comunicaciones S.A.
 
-8. «COPACO»: Compañía Paraguaya de Comunicaciones S.A.
+8. «AEP»: Agencia Espacial del Paraguay.
 
-9. «AEP»: Agencia Espacial del Paraguay.
-
-10. «IID»: Investigación, Innovación y Desarrollo
+9. «IID»: Investigación, Innovación y Desarrollo
 
 ### Art. 6º.- Objetivos del Ministerio.
 
 El «Ministerio» tendrá los siguientes objetivos:
 
-**1.** Elaborar, promover, implementar y supervisar las políticas públicas, planes, programas y proyectos del sector de las Tecnologías de la Información y la Comunicación y de sectores convergentes, así como su ordenamiento general, en concordancia con la Constitución de la República del Paraguay y las leyes.
+**1.** Elaborar, promover, implementar y supervisar las políticas públicas, planes, programas y proyectos del sector de las «TIC» y de sectores convergentes, así como su ordenamiento general, en concordancia con la Constitución de la República del Paraguay y las leyes.
 
 **2.** Promover, incrementar y facilitar el uso de las «TIC», buscando siempre la participación y el acceso efectivo en igualdad de oportunidades a todos los habitantes de la República, con la mayor cobertura y calidad de servicios posibles; así como propiciar el uso eficiente de las redes informáticas, la IID, formación del talento humano y la competencia a nivel nacional e internacional.
 
 **3.** Impulsar el desarrollo y el fortalecimiento del sector, la innovación tecnológica, economía digital, mediante políticas públicas que involucren a todos los niveles de los «OEE» y de la sociedad.
 
-**4.** Desarrollar procesos y estrategias de Comunicación para la difusión de la información que generen los «OEE» y la parte paraguaya de los Organismos Binacionales o Multilaterales, de manera a lograr que la difusión de la información sea realizada en forma ágil y oportuna e incentivando la apropiación social y educativa de las tecnologías para implementación adecuada, una interacción comunicacional participativa, plural y transparente entre el Poder Ejecutivo y los habitantes de la República del Paraguay.
+**4.** Desarrollar estándares para mejorar los procesos de las OEE y la parte paraguaya de los Organismos Binacionales o Multilaterales, realizada en forma ágil y oportuna e incentivando la apropiación social y educativa de las tecnologías para implementación adecuada, una interacción comunicacional participativa, plural y transparente entre el Poder Ejecutivo y los habitantes de la República del Paraguay.
+
+**5.** Definir estandares y metodologias que serán de aplicación obligatoria en todas las entidades del Estado, de tal forma que se contruya, opere y mantenga la infraestructura de las «TIC»
 
 ### Art. 7º.- Competencias.
 
 El «Ministerio», tendrá las siguientes competencias:
 
-**1.** Diseñar, planificar, adoptar, ejecutar y promover las políticas, planes, programas y proyectos del sector de las Tecnologías de la Información y Comunicación que contribuyan al mejoramiento de la calidad de vida de las comunidades, el acceso a las nuevas tecnologías y a la información de manera a contribuir a generar oportunidades de educación, trabajo, salud, justicia, cultura y recreación, entre otras.
+**1.** Diseñar, planificar, adoptar, ejecutar y promover las políticas, planes, programas y proyectos del sector de las «TIC» que contribuyan al mejoramiento de la calidad de vida de las comunidades, el acceso a las nuevas tecnologías y a la información de manera a contribuir a generar oportunidades de educación, trabajo, salud, justicia, cultura y recreación, entre otras.
 
 **2.** Establecer y gestionar políticas de protección de la información personal y gubernamental, y cultivar los conocimientos sobre la industria de seguridad de la información, para lo cual deberá establecer un sistema de organización de seguridad, proponer una política de seguridad a nivel nacional, y establecer un plan de integración de protección de información.
 
@@ -87,7 +87,7 @@ El «Ministerio», tendrá las siguientes competencias:
 
 **6.** Implementar y administrar la infraestructura tecnológica vinculada con redes públicas y centro de datos del Poder Ejecutivo.
 
-**7.** Orientar, priorizar y dirigir el proceso de incorporación y mantenimiento de las Tecnologías de la Información y Comunicación (TIC) en la gestión pública, definiendo los diversos componentes, etapas y secuencias del proceso que deben ser implementados por los Organismos y Entidades del Estado, que tengan incidencia directa en el fortalecimiento de la eficacia, eficiencia y transparencia de las prestaciones y servicios públicos.
+**7.** Orientar, priorizar y dirigir el proceso de incorporación y mantenimiento de las «TIC» en la gestión pública, definiendo los diversos componentes, etapas y secuencias del proceso que deben ser implementados por los Organismos y Entidades del Estado, que tengan incidencia directa en el fortalecimiento de la eficacia, eficiencia y transparencia de las prestaciones y servicios públicos.
 
 **8.** Aprobar y apoyar los planes, proyectos y actividades ejecutadas por los Organismos y Entidades del Estado, en el cumplimiento de sus fines, vinculados al sector de TIC.
 
@@ -117,7 +117,7 @@ El «Ministerio», tendrá las siguientes competencias:
 
 **21.** Asesorar y prestar asistencia técnica a entidades estatales, privadas, organizaciones civiles, gobiernos departamentales y municipales, a solicitud de los mismos; así como también promover y coordinar con ellos las iniciativas que guarden relación con los fines de esta ley.
 
-**22.** Implementar estrategias de supervisión y fiscalización en la ejecución de los proyectos ejecutados en el marco de los programas y planes del «Ministerio», así como ejercer facultades de verificación y control en todo lo concerniente a tecnologías de la información y de la comunicación, realizadas por los «OEE».
+**22.** Implementar estrategias de supervisión y fiscalización en la ejecución de los proyectos ejecutados en el marco de los programas y planes del «Ministerio», así como ejercer facultades de verificación y control en todo lo concerniente a «TIC», realizadas por los «OEE».
 
 **23.** Ejercer la autoridad de administración de los fondos del «FONTIC» destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de sus fines.
 
@@ -135,7 +135,7 @@ El Ministro es nombrado por decreto del Poder Ejecutivo y debe cumplir con los s
 
 **2.** Haber cumplido veinticinco (25) años de edad;
 
-**3.** Tener probada idoneidad técnica y amplia experiencia en el sector de las Tecnologías de la Información y Comunicación.
+**3.** Tener probada idoneidad técnica y amplia experiencia en el sector de las «TIC».
 
 **4.** Estar en pleno goce de los derechos civiles y políticos. No registrar antecedentes de mal desempeño en la función pública.
 
@@ -153,7 +153,7 @@ Son deberes y atribuciones del Ministro:
 
 **4.** Velar por el cumplimiento de las normas aplicables al «Ministerio» y adoptar las medidas necesarias para asegurar su normal funcionamiento.
 
-**5.** Asumir la representación como máxima y exclusiva autoridad en cuestiones de políticas y acciones de las Tecnologías de la Información y de Comunicación.
+**5.** Asumir la representación como máxima y exclusiva autoridad en cuestiones de políticas y acciones de las «TIC».
 
 **6.** Elaborar el anteproyecto de presupuesto del «Ministerio» y someterlo al órgano ministerial competente en los plazos legales previstos y acompañar su estudio hasta su promulgación, y ejecutarlo conforme con la planificación anual.
 
@@ -183,17 +183,17 @@ Son deberes y atribuciones del Ministro:
 
 **19.** Elevar al Poder Ejecutivo la propuesta de creación, modificación, ampliación, abrogación o derogación de leyes, decretos o normativas en ejercicio de su competencia.
 
-**20.** Diseñar, implementar y supervisar la aplicación de las políticas de las Tecnologías de la Información y Comunicación en los programas y proyectos del Poder Ejecutivo, de acuerdo con las normativas legales vigentes.
+**20.** Diseñar, implementar y supervisar la aplicación de las políticas de las «TIC» en los programas y proyectos del Poder Ejecutivo, de acuerdo con las normativas legales vigentes.
 
 **21.** Diseñar las estrategias y acuerdos necesarios para el desarrollo de trabajos participativos con las organizaciones civiles.
 
 **22.** Obtener, gestionar, y administrar los recursos asignados para los fines específicos de la presente ley y los fondos creados para el sector, así como el cuidado de los bienes o patrimonio de la institución.
 
-**23.** Suscribir convenios, acuerdos y otras formas de cooperación en materia de temas de Tecnologías de la Información y Comunicación, que propicie la investigación e intercambio de conocimientos y experiencias, y movilice además los recursos nacionales y externos para la ejecución de planes y programas relacionados al sector de las «TIC» y la Comunicación.
+**23.** Suscribir convenios, acuerdos y otras formas de cooperación en materia de temas de «TIC», que propicie la investigación e intercambio de conocimientos y experiencias, y movilice además los recursos nacionales y externos para la ejecución de planes y programas relacionados al sector de las «TIC».
 
 **24.** Administrar los fondos destinados al sector de las «TIC» y otros fondos creados para el cumplimiento de los fines del «Ministerio».
 
-**25.** Propiciar y realizar todo tipo de estudios, análisis y reglamentaciones referidas al sector de las Tecnologías de la Información y Comunicación.
+**25.** Propiciar y realizar todo tipo de estudios, análisis y reglamentaciones referidas al sector de las «TIC».
 
 **26.** Resolver los recursos administrativos que se interpongan ante él, de conformidad a la ley.
 
@@ -215,17 +215,21 @@ El «Ministerio» contará con la siguiente estructura orgánica:
 
 **c)** Secretaria General;
 
-**d)** Viceministerio de Tecnologías de la Información y Comunicación (TIC);
+**d)** Viceministerio de Infraestructura digital;
 
-**e)** Viceministerio de Comunicación
+**e)** Viceministerio de Transformación digital;
 
-**f)** Dirección General de Asesoría Jurídica;
+**g)** Viceministerio de Inclusión digital;
 
-**g)** Dirección General de Administración y Finanzas;
+**h)** Viceministerio de Economía digital;
 
-**h)** Auditoría Interna; y,
+**i)** Dirección General de Asesoría Jurídica;
 
-**i)** Otras Direcciones Generales y dependencias que fueren necesarias para el cumplimiento de los objetivos del «Ministerio».
+**j)** Dirección General de Administración y Finanzas;
+
+**k)** Auditoría Interna; y,
+
+**l)** Otras Direcciones Generales y dependencias que fueren necesarias para el cumplimiento de los objetivos del «Ministerio».
 
 En caso de sustitución del Ministro, los cargos de los titulares de las unidades orgánicas detalladas en el presente artículo, estarán a disposición de la nueva autoridad designada por el Poder Ejecutivo, pudiendo ser reasignados según necesidad o destituidos sin más trámites por término de funciones.
 
@@ -233,27 +237,43 @@ En caso de sustitución del Ministro, los cargos de los titulares de las unidade
 
 El «Ministerio» podrá incorporar en su organigrama a las Direcciones Generales o dependencias similares que considere necesarias para el cumplimiento de sus objetivos. Los Viceministerios contarán cuanto menos con las siguientes Direcciones Generales:
 
-##### 1. Viceministerio de Tecnologías de la Información y Comunicación (TIC):
+#### 1. Viceministerio de Infraestructura digital:
 
-**a)**  Dirección General de Infraestructura y Conectividad
+**a)** Dirección General de Conectividad y Sistemas
 
-**b)**  Dirección General de Gobierno Electrónico.
+**b)** Dirección General de Gestión de Recursos Digitales
 
-**c)**  Dirección General de Inclusión Digital y TIC en la Educación
+**c)** Dirección General de Seguridad
 
-**d)** Dirección General de Innovación Productiva y Economía Digital
+**d)** Dirección General de Estándares
 
-**e)** Dirección General de Ciberseguridad y Protección de la Información
+**e)** Dirección General de Planificación
 
-##### 2. Viceministerio de Comunicación:
+#### 2. Viceministerio de Transformación Digital
 
-**a)**  Dirección General de Educación y Comunicación para el Bienestar.
+**a)** Dirección General de Transformación digital
 
-**b)**  Dirección General de Comunicación Estratégica.
+**b)** Dirección General de Gestión del Conocimiento
 
-**c)**  Dirección General de Información Presidencial.
+**c)** Dirección General de Gobierno Electrónico
 
-**d)**  Dirección General de Medios del Estado.
+#### 3. Viceministerio de Inclusión Digital
+
+**a)** Dirección General de Educación Digital
+
+**b)** Dirección General de Inclusión Digital
+
+**c)** Dirección General de Capacidad Digital
+
+**d)** Dirección General de Medios Digitales
+
+#### 4. Viceministerio de Economía Digital
+
+**a)** Dirección General de Industria
+
+**b)** Dirección General de Comercio 
+
+**c)** Dirección General de Innovación Industrial
 
 ### Art. 13º.- Nombramientos.
 
@@ -267,6 +287,8 @@ Para ejercer los cargos de Viceministros, Secretario General, Directores General
 
 Dichos cargos serán ejercidos a tiempo completo y con dedicación exclusiva y es incompatible con el ejercicio de otra actividad, con o sin remuneración, debiendo dedicarse en exclusividad a sus funciones salvo el ejercicio de la docencia a tiempo parcial y opuesto al horario laboral siempre que ella no perturbe el ejercicio de sus funciones.
 
+Los cargos de Viceministros serán ocupados por profesionales con titulo universitario de grado de las carreras de Analisis de Sistemas, de Ingeniería Informática o de Ingeniería Electrónica según especialidad del viceministerio. En ningún caso se aceptarán profesionales con titulo de grado de otras carreras o con maestrías o doctorados en «TIC».
+
 ### Art. 15º.- Organización interna. Facultad de modificar, ampliar y establecer funciones y atribuciones a la Organización del Ministerio.
 
 Se podrá modificar y ampliar la estructura organizacional y los niveles de dependencias del «Ministerio», y establecer las funciones y atribuciones de las mismas conforme a las competencias asignadas en la presente ley, por decreto del Poder Ejecutivo.
@@ -275,7 +297,7 @@ Se podrá modificar y ampliar la estructura organizacional y los niveles de depe
 
 El patrimonio del «Ministerio» está constituido por:
 
-1. La totalidad del activo y pasivo de la «SENATICS» y de la «SICOM» constituidos por muebles, inmuebles, derechos, acciones, garantías o privilegios, subrogándose de pleno derecho al «Ministerio» en todas las acciones y derechos que aquellas Instituciones detentan a la fecha.
+1. La totalidad del activo y pasivo de la «SENATICS» constituidos por muebles, inmuebles, derechos, acciones, garantías o privilegios, subrogándose de pleno derecho al «Ministerio» en todas las acciones y derechos que aquellas Instituciones detentan a la fecha.
 
 2. Los bienes adquiridos en el futuro para el cumplimiento de sus fines.
 
@@ -307,19 +329,19 @@ Constituyen recursos económicos y recursos patrimoniales del «Ministerio»:
 
 ### Art. 18º.- Absorción del «FONTIC». Componentes.
 
-El «Ministerio» absorbe como parte de sus recursos económicos, el «FONTED» el cual pasará a llamarse «FONTIC», constituido con la finalidad de lograr los objetivos vinculados con programas de Tecnología de la Información y Comunicación
+El «Ministerio» absorbe como parte de sus recursos económicos, el «FONTED» el cual pasará a llamarse «FONTIC», constituido con la finalidad de lograr los objetivos vinculados con programas de «TIC».
 
 Forman parte del «FONTIC»:
 
-**1.** Los fondos provenientes de convenios o acuerdos con instituciones nacionales o internacionales, públicas o privadas que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC».
+**1.** Los fondos provenientes de convenios o acuerdos con instituciones nacionales o internacionales, públicas o privadas que se enmarquen en programas relacionados con las «TIC».
 
-**2.** Los recursos provenientes de la cooperación técnica internacional, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
+**2.** Los recursos provenientes de la cooperación técnica internacional, que se enmarquen en programas relacionados con las «TIC»
 
 **3.** El cincuenta por ciento (50 %) de los recursos afectados al Fondo de Servicios Universales, administrado por la Comisión Nacional de Telecomunicaciones «CONATEL».
 
 **4.** Los recursos provenientes de los Royalties y Compensaciones que corresponden a la Administración Central, de conformidad a lo establecido en el inciso a) del Artículo 1º de la Ley Nº 3984/2010, en un monto que deberá establecerse en cada Ejercicio Fiscal.
 
-**5.** Además, podrán formar parte de los recursos del «FONTIC» las donaciones, legados, transferencias u otros aportes, por cualquier título proveniente de personas naturales o jurídicas nacionales o extranjeras, que se enmarquen en programas relacionados con las Tecnologías de la Información y Comunicación «TIC»
+**5.** Además, podrán formar parte de los recursos del «FONTIC» las donaciones, legados, transferencias u otros aportes, por cualquier título proveniente de personas naturales o jurídicas nacionales o extranjeras, que se enmarquen en programas relacionados con las «TIC»
 
 ### Art. 19º.- Colaboración y asistencia de los «OEE» y del sector privado.
 
@@ -339,19 +361,19 @@ La utilización de los medios electrónicos deberá ser reglamentada y deberá a
 
 ### Art. 23º.- Personal, bienes y recursos financieros.
 
-A partir de la vigencia de la presente ley, el personal, bienes y recursos financieros de la «SENATICS» y de la «SICOM» pasarán a formar parte del «Ministerio».
+A partir de la vigencia de la presente ley, el personal, bienes y recursos financieros de la «SENATICS» pasarán a formar parte del «Ministerio».
 
-Todos los derechos y acciones atribuidos por leyes especiales a la «SENATICS» y a la «SICOM», quedan subrogados a favor del «Ministerio».
+Todos los derechos y acciones atribuidos por leyes especiales a la «SENATICS», quedan subrogados a favor del «Ministerio».
 
-A los efectos de determinar el patrimonio del «Ministerio», la «SENATICS» y la «SICOM» deberán proceder a un inventario general de los bienes, derechos y obligaciones.
+A los efectos de determinar el patrimonio del «Ministerio», la «SENATICS» deberán proceder a un inventario general de los bienes, derechos y obligaciones.
 
 ### Art. 24º.- Personal.
 
-**1.** El personal que, a la fecha de la promulgación de la presente ley, forme parte del anexo del personal de la «SENATICS» y de la «SICOM», pasará a formar parte de la nómina inicial del «Ministerio» y gozará de la misma antigüedad, régimen de jubilación y demás derechos adquiridos. Se regirán por esta ley, sus reglamentos, la Ley de la Función Pública, sus normas complementarias y reglamentarias.
+**1.** El personal que, a la fecha de la promulgación de la presente ley, forme parte del anexo del personal de la «SENATICS», pasará a formar parte de la nómina inicial del «Ministerio» y gozará de la misma antigüedad, régimen de jubilación y demás derechos adquiridos. Se regirán por esta ley, sus reglamentos, la Ley de la Función Pública, sus normas complementarias y reglamentarias.
 
-**2.** El personal, que a la fecha de promulgación de esta ley forme parte del anexo del personal de la «SENATICS» y de la «SICOM», y que ya cumpliese con los requisitos de la jubilación ordinaria, deberá acogerse a los beneficios de la misma.
+**2.** El personal, que a la fecha de promulgación de esta ley forme parte del anexo del personal de la «SENATICS», y que ya cumpliese con los requisitos de la jubilación ordinaria, deberá acogerse a los beneficios de la misma.
 
-**3.** El personal contratado que se encuentre prestando servicios en la «SENATICS» y en la «SICOM», continuará prestando dichos servicios en los mismos términos y condiciones contractuales.
+**3.** El personal contratado que se encuentre prestando servicios en la «SENATICS», continuará prestando dichos servicios en los mismos términos y condiciones contractuales.
 
 **4.** El Ministro del «Ministerio» podrá implementar un sistema de retiro voluntario incentivado, de acuerdo con la disponibilidad presupuestaria, para el personal que, a la fecha de la promulgación de la presente ley, desee acogerse a los beneficios de este sistema.
 
@@ -373,9 +395,9 @@ A partir de la entrada en vigencia de la presente Ley las relaciones de la «AEP
 
 El «Ministerio» integrará el Consejo Nacional de Ciencia y Tecnología (CONACYT), para lo cual el Ministro deberá designar a un representante titular y un representante suplente, los cuales serán nombrados como consejeros por Decreto del Poder Ejecutivo.
 
-### Art. 28º.- Extinción de «SENATICS» y «SICOM».
+### Art. 28º.- Extinción de «SENATICS».
 
-La «SENATICS» y la «SICOM» dependiente de la Presidencia de la República, quedarán extinguidas de pleno derecho a partir de la entrada en vigencia de la presente ley.
+La «SENATICS» dependiente de la Presidencia de la República, quedarán extinguidas de pleno derecho a partir de la entrada en vigencia de la presente ley.
 
 ### Art. 29º.- Ministerio de Obras Públicas.
 
@@ -383,7 +405,7 @@ A partir de la entrada en vigencia de la presente ley, el Ministerio de Obras P�
 
 ### Art. 30º.- Derogación.
 
-Queda derogada la Ley Nº 4989/ 2013 «Que crea el Marco de Aplicación de las Tecnologías de la Información y Comunicación en el Sector Público y crea la Secretaría Nacional de la Tecnologías de la Información y Comunicación (SENATICS)» y  todas las disposiciones contrarias a la presente Ley a partir de su entrada en vigor.
+Queda derogada la Ley Nº 4989/ 2013 «Que crea el Marco de Aplicación de las «TIC» en el Sector Público y crea la Secretaría Nacional de la Tecnologías de la Información y Comunicación (SENATICS)» y  todas las disposiciones contrarias a la presente Ley a partir de su entrada en vigor.
 
 ### Art. 31º.- Tiempo máximo de adecuación.
 


### PR DESCRIPTION
Se reescribieron todos los artículos eliminando la relacionado a SICOM y utilizando donde corresponde las siglas TIC para referirnos a Tecnologías de la Información y Comunicación. 